### PR TITLE
Update tradfri.py

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -107,10 +107,15 @@ class Tradfri(Light):
 
         if self._light_data.hex_color is not None:
             if self._light.device_info.manufacturer == IKEA:
-                self._features |= SUPPORT_COLOR_TEMP
+                if "CWS" in self._light.device_info.model_number:
+                    self._features |= SUPPORT_RGB_COLOR
+                else:
+                    self._features |= SUPPORT_COLOR_TEMP
             else:
                 self._features |= SUPPORT_RGB_COLOR
-
+            
+        _LOGGER.debug("features detected for %s %s: %d", self._name, self._light.device_info.model_number, self._features)
+        
         self._ok_temps = \
             self._light.device_info.manufacturer in ALLOWED_TEMPERATURES
 


### PR DESCRIPTION
Added feature detection (SUPPORT_RGB_COLOR) for IKEA tradfri RGB bulbs. 

String comparison with manufacturer/device id used because I think there isn't a suitable property/param to identify the RGB capability. Both IKEA WS and RGB have data in the same parameters (x, y, rgb). 

Color picker in UI is only offered after one of the default RGB colors (i.e. efd275) is set in param 5706. For now I couldn't find the section in polymer where the decision (to show a color picker or not) is made. 

see also: 
<https://github.com/home-assistant/home-assistant/issues/ 9 6 0 3>

Tested with the following setup:
Home Assistant 0.53.1
pytradfri 2.2
IKEA tradfri gateway fw 1.1.0015
zigbee rgb PWM module (dresden elektronik FLS-PP lp)
IKEA RGB, WS and dimmable-only bulbs

## Description:


**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
scene:
  - name: daytime
    entities:
      light.kitchen:
        state: on
        brightness: 63
        rgb_color: [255, 191, 0]
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ na ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ na ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ na ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ na ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ na ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ na ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
